### PR TITLE
Add prefix option to install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ A C compiler is needed to install from source. The makefile uses `gcc`.
 
 You can use the install script to clone and compile jumper + set up the shell keybindings automatically:
 ```sh
-sh -c "$(curl -s https://raw.githubusercontent.com/homerours/jumper/master/install.sh)"
+PREFIX=$HOME/.local/bin sh -c "$(curl -s https://raw.githubusercontent.com/homerours/jumper/master/install.sh)"
 ```
 
 #### Manual installation

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,11 @@ git clone https://github.com/homerours/jumper
 cd jumper
 echo
 echo "Building jumper's binary..."
-make install
+if [ -z "$PREFIX" ]; then
+    make install
+else
+    make PREFIX="$PREFIX" install
+fi
 
 cd "$CURRENT_DIR"
 


### PR DESCRIPTION
Minimal edit to the install script to add an option to customize the installation location with the `PREFIX` environment variable.