### PR TITLE
Add a `--no-bind` option for shell

### DIFF
--- a/src/arguments.c
+++ b/src/arguments.c
@@ -39,7 +39,7 @@ static const char HELP_STRING[] =
     " -e, --existing            Only print files/directories that exist in the "
     "file system.\n"
     " -I, --case-insensitive    Make the search case-insensitive.\n"
-    " -S, --case-sensitive      Make the search case-sensititive.\n"
+    " -S, --case-sensitive      Make the search case-sensitive.\n"
     " -H, --home-tilde          Substitute $HOME with ~ when printing "
     "results.\n"
     " -r, --relative=PATH       Outputs relative paths to PATH if\n"
@@ -48,7 +48,8 @@ static const char HELP_STRING[] =
     " -w, --weight=WEIGHT       Weight of the visit (default=1.0).\n\n"
     "MODE clean: remove entries that do not exist anymore.\n"
     "MODE status: print databases' locations and some statistics.\n"
-    "MODE shell: print setup scripts. ARG has to be bash, zsh or fish.\n";
+    "MODE shell: print setup scripts. ARG has to be bash, zsh or fish.\n"
+    " -B, --no-bind             Do not bind keys.\n";
 
 static void help(const char *argv0) { printf(HELP_STRING, argv0); }
 
@@ -69,6 +70,7 @@ static struct option longopts[] = {{"file", required_argument, NULL, 'f'},
                                    {"orderless", no_argument, NULL, 'o'},
                                    {"existing", no_argument, NULL, 'e'},
                                    {"type", required_argument, NULL, 't'},
+                                   {"no-bind", no_argument, NULL, 'B'},
                                    {NULL, 0, NULL, 0}};
 
 static void args_init(Arguments *args) {
@@ -90,6 +92,7 @@ static void args_init(Arguments *args) {
   // score.
   args->beta = 1.0;
   args->weight = 1.0;
+  args->no_bind = false;
 }
 
 static MODE parse_mode(const char *mode) {
@@ -242,7 +245,7 @@ Arguments *parse_arguments(int argc, char **argv) {
   optind++;
   int c = 0;
   while (optind < argc && c != -1) {
-    c = getopt_long(argc, argv, "csoeHISt:f:n:w:b:x:r::", longopts, NULL);
+    c = getopt_long(argc, argv, "csoeHISt:f:n:w:b:x:r::B", longopts, NULL);
     if (c != -1) {
       switch (c) {
       case 'f':
@@ -320,6 +323,9 @@ Arguments *parse_arguments(int argc, char **argv) {
               "ERROR: The weight of a visit (-w option) can't be negative.\n");
           exit(EXIT_FAILURE);
         }
+        break;
+      case 'B':
+        args->no_bind = true;
         break;
       default:
         help(argv[0]);

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -27,6 +27,7 @@ typedef struct Arguments {
   bool home_tilde;
   bool orderless;
   bool existing;
+  bool no_bind;
   TYPE type;
   int n_results;
   const char *relative_to;

--- a/src/jumper.c
+++ b/src/jumper.c
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
   } else if (args->mode == MODE_clean) {
     clean_database(args);
   } else if (args->mode == MODE_shell) {
-    shell_setup(args->key);
+    shell_setup(args->key, args->no_bind);
   }
   free(args);
   return EXIT_SUCCESS;

--- a/src/shell.c
+++ b/src/shell.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -136,7 +137,9 @@ static const char bash_functions[] =
 static const char bash_bindings[] =
     "bind -x '\"\\C-y\": jumper-find-dir'\n"
     "stty kill undef\n"
-    "bind -x '\"\\C-u\": jumper-find-file'\n"
+    "bind -x '\"\\C-u\": jumper-find-file'\n";
+
+static const char bash_prompt[] =
     "PROMPT_COMMAND=\"__jumper_update_db;$PROMPT_COMMAND\"\n";
 
 static const char zsh_variables[] =
@@ -276,10 +279,11 @@ static const char zsh_functions[] =
 static const char zsh_bindings[] = "zle -N jumper-find-dir\n"
                                    "zle -N jumper-find-file\n"
                                    "bindkey '^Y' jumper-find-dir\n"
-                                   "bindkey '^U' jumper-find-file\n"
-                                   "precmd() {\n"
-                                   "    __jumper_update_db\n"
-                                   "}\n";
+                                   "bindkey '^U' jumper-find-file\n";
+
+static const char zsh_prompt[] = "precmd() {\n"
+                                 "    __jumper_update_db\n"
+                                 "}\n";
 
 static const char fish_variables[] =
     "if not set -q __JUMPER_FLAGS\n"
@@ -404,19 +408,21 @@ static const char fish_functions[] =
 static const char fish_bindings[] = "bind \\cy jumper-find-dir\n"
                                     "bind \\cu jumper-find-file\n";
 
-void shell_setup(const char *shell) {
+void shell_setup(const char *shell, bool no_bind) {
   if (strcmp(shell, "bash") == 0) {
     printf(bash_variables);
     printf(bash_functions);
-    printf(bash_bindings);
+    if (!no_bind) printf(bash_bindings);
+    printf(bash_prompt);
   } else if (strcmp(shell, "zsh") == 0) {
     printf(zsh_variables);
     printf(zsh_functions);
-    printf(zsh_bindings);
+    if (!no_bind) printf(zsh_bindings);
+    printf(zsh_prompt);
   } else if (strcmp(shell, "fish") == 0) {
     printf(fish_variables);
     printf(fish_functions);
-    printf(fish_bindings);
+    if (!no_bind) printf(fish_bindings);
   } else {
     fprintf(stderr, "ERROR: Invalid argument for shell: %s.\n", shell);
     fprintf(stderr, "Accepted arguments: bash, zsh, fish.\n");

--- a/src/shell.h
+++ b/src/shell.h
@@ -1,3 +1,3 @@
 #pragma once
 
-void shell_setup(const char *shell);
+void shell_setup(const char *shell, bool no_bind);


### PR DESCRIPTION
Add a `-B`/`--no-bind `option to jumper shell to disable key bindings, preventing them from overriding existing user configurations. Default behavior remains unchanged.